### PR TITLE
Use version range for support library dependency and push sdk version to 21 in gradle build. 

### DIFF
--- a/appPDPj-lib/build.gradle
+++ b/appPDPj-lib/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 'Google Inc.:Google APIs:22'
-    buildToolsVersion "21.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 19
@@ -17,15 +17,15 @@ android {
       main {
         manifest.srcFile 'AndroidManifest.xml'
         java.srcDirs = ['src']
-        
+
         resources.srcDirs = ['src']
         aidl.srcDirs = ['src']
-        
+
         renderscript.srcDirs = ['src']
-        
+
         res.srcDirs = ['res']
         assets.srcDirs = ['assets']
-        
+
       }
     }
 

--- a/cm4Android/build.gradle
+++ b/cm4Android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 19
@@ -17,15 +17,15 @@ android {
       main {
         manifest.srcFile 'AndroidManifest.xml'
         java.srcDirs = ['src']
-        
+
         resources.srcDirs = ['src']
         aidl.srcDirs = ['src']
-        
+
         renderscript.srcDirs = ['src']
-        
+
         res.srcDirs = ['res']
         assets.srcDirs = ['assets']
-        
+
       }
     }
 

--- a/uclib4Android/build.gradle
+++ b/uclib4Android/build.gradle
@@ -13,18 +13,18 @@ android {
       main {
         manifest.srcFile 'AndroidManifest.xml'
         java.srcDirs = ['src']
-        
+
         resources.srcDirs = ['src']
         aidl.srcDirs = ['src']
-        
+
         renderscript.srcDirs = ['src']
-        
+
         res.srcDirs = ['res']
         assets.srcDirs = ['assets']
-        
+
       }
     }
-    
+
     buildTypes {
         release {
             minifyEnabled false
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:19.1.0'
+    compile 'com.android.support:support-v4:19.+'
     compile 'com.google.guava:guava:16.0.1'
     compile files('libs/activation.jar')
     compile files('libs/additionnal.jar')

--- a/uclib4Android/build.gradle
+++ b/uclib4Android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "21.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 19
@@ -34,7 +34,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:19.+'
+    compile 'com.android.support:support-v4:21.+'
     compile 'com.google.guava:guava:16.0.1'
     compile files('libs/activation.jar')
     compile files('libs/additionnal.jar')


### PR DESCRIPTION
The support library dependency used a fixed minor version which was removed by Google so the gradle build failed on fresh machines. Using a version range `21.+` should fix this. Also the compile sdk versions were changed to `21` uniformly so only one version is required for building (converged with the rs3appstore client version).
